### PR TITLE
Basic functionality for Morningstar's On Demand 

### DIFF
--- a/config-morningstar.yml.dist
+++ b/config-morningstar.yml.dist
@@ -5,3 +5,7 @@ provider:
   morningstar:
     username: foo
     password: bar
+  ondemand:
+    clientid: baz
+    username: foo
+    password: bar

--- a/morningstar/models/rips.py
+++ b/morningstar/models/rips.py
@@ -1,0 +1,12 @@
+class RIPS:
+    __slots__ = ('SecId', 'PerformanceId', 'Date', 'Deleted', 'Unit_BAS', 'Unit_USD', 'Unit_EUR', 'Unit_GBP',
+                 'Unit_CHF', 'Unit_DKK', 'Unit_NOK', 'Unit_SEK', 'Unit_JPY', 'LastUpdate', 'Unit_SGD',
+                 'ReturnType', 'Filled', 'Unit_TWD', 'Unit_HKD', 'Unit_MYR', 'Unit_CNY', 'Unit_ILS', 'Unit_INR',
+                 'Unit_CAD', 'Unit_KWD', 'Unit_PLN', 'Unit_AUD', 'Unit_THB', 'Unit_KRW', 'Unit_NZD')
+
+    @classmethod
+    def from_dict(cls, row: dict):
+        obj = cls()
+        for k, v in row.items():
+            setattr(obj, k, v)
+        return obj

--- a/morningstar/on_demand_client.py
+++ b/morningstar/on_demand_client.py
@@ -1,0 +1,102 @@
+from morningstar.provider.on_demand import OnDemand
+from morningstar.config import config
+from morningstar.models.rips import RIPS
+from morningstar.spec.on_demand_spec import OnDemandReturnType
+from lxml import etree
+from typing import Optional
+
+
+class OnDemandClient():
+
+    xpath_share_performanceid_basecurrency = "/FundShareClass/PerformanceId/Result[./IsBaseCurrency = 'true']/PerformanceId/text()"
+    xpath_universe_morningstarid = "/FundShareClassList/ShareClass/Id/text()"
+
+    def __init__(self, provider=None):
+        """ Wraps Provider
+
+        Args:
+            provider (Provider): provider instance
+        """
+        if provider is None:
+            provider = OnDemand(config=config.get('provider')['ondemand'])
+        self.provider = provider
+
+
+    def get_historical_rips(self,
+                            isin: str,
+                            return_type: OnDemandReturnType,
+                            start_date: str = '',
+                            end_date: str = '',
+                            universe: str = '') -> [RIPS]:
+        """Fetches RIPS for the fundshare with the given ISIN using the performance id in basecurrency
+
+            Note:
+                The ISIN is searched in the specified universe to obtain the morningstar id its associated performance id.
+                If the share is obsolete for too long (45d), or not found in the given universe, or if no
+                performance id in base currency can be found, a ValueError is raised. 
+
+            Args:
+                isin (str): e.g. "IE00BYML7P29"
+                return_type (OnDemandReturnType): e.g. TotalReturn
+                start_date (str): "%Y-%m-%d"
+                end_date (str): "%Y-%m-%d"
+                universe (str): e.g. "CHE"
+
+            Returns:
+                List of RIPS objects with one for each date
+            """
+
+        # Login before using any other method of provider
+        self.provider.login()
+
+        # Get universe to find Morningstar Id corresponding to isin
+        #   no start and end date for search of isin in universe.
+        #   Should be everything possible
+        data_get_fundshare_universe = {'ClientId': self.provider.config['clientid'],
+                                       'ActiveStatus':  '',     # obsolete and active, max coverage (last 45d)
+                                       'InvestorType': '',      # both, dont care as only to get id
+                                       'LegalStructureId': '',  # all types of funds
+                                       'ISIN': isin,
+                                       'CountryId': universe}
+        root_n_universe = self.provider.get_universe(params=data_get_fundshare_universe)
+
+        # read out ms id from universe xml
+        #   It is unfortunately possible that a search by ISIN results in the correct fundshare which has
+        #   a different ISIN than the one used for searching. In the resulting universe xml, it is also only
+        #   listed with this other ISIN and hence cannot be found by subsetting in the xpath with the searched ISIN.
+        #   (ie by using [./ISIN = '"+isin+"'] in xpath). Therefore, because only maximum a single share 
+        #   should be found, read out directly withouth searching by ISIN in the xml
+        ms_id = root_n_universe.xpath(self.xpath_universe_morningstarid)
+        if len(ms_id) == 0:
+            raise ValueError(
+                "No Morningstar Id could be found for the given ISIN. Maybe the share is dead for too long or in a different universe?")
+        if len(ms_id) > 1:
+            raise ValueError(
+                "More than one Morningstar Id found for this ISIN.")
+        ms_id = str(ms_id[0])
+
+        # With this morningstar id, get the respective share's xml and its performance id for basecurrency
+        params_sharexml = {'Package': 'EDW', 'IDType': 'FundShareClassId',
+                           'ClientId': self.provider.config['clientid'],
+                           'Id': ms_id}
+        root_n_share = self.provider.data_output(params=params_sharexml)
+
+        share_performanceid_basecurrency = root_n_share.xpath(
+            self.xpath_share_performanceid_basecurrency)
+        if len(share_performanceid_basecurrency) == 0:
+            raise ValueError(
+                "No performance id in basecurrency could be found")
+        if len(share_performanceid_basecurrency) > 1:
+            raise ValueError(
+                "More than 1 performance id in basecurrency was found: "+str(share_performanceid_basecurrency))
+        share_performanceid_basecurrency = str(
+            share_performanceid_basecurrency[0])
+
+        # Download csv data from this performance id
+        params_historydata = {'ClientId': self.provider.config['clientid'],
+                              'DataType': 'rips',
+                              'StartDate': start_date,
+                              'EndDate': end_date,
+                              'PriceType': str(return_type.value),
+                              'PerformanceId': share_performanceid_basecurrency}
+        return self.provider.history_data(params=params_historydata)

--- a/morningstar/on_demand_client.py
+++ b/morningstar/on_demand_client.py
@@ -22,36 +22,115 @@ class OnDemandClient():
         self.provider = provider
 
 
-    def get_historical_rips(self,
-                            isin: str,
-                            return_type: OnDemandReturnType,
-                            start_date: str = '',
-                            end_date: str = '',
-                            universe: str = '') -> [RIPS]:
-        """Fetches RIPS for the fundshare with the given ISIN using the performance id in basecurrency
+
+    def get_historical_rips_by_performanceid(self,
+                                            performance_id: str,
+                                            return_type: OnDemandReturnType,
+                                            start_date: str = '',
+                                            end_date: str = '') -> [RIPS]:
+        """Fetches historical RIPS for the given performance id
+
+            Args:
+                performance_id (str): e.g. "0P0000OO1Z"
+                return_type (OnDemandReturnType): e.g. TotalReturn
+                start_date (str): "%Y-%m-%d"
+                end_date (str): "%Y-%m-%d"
+
+            Returns:
+                List of RIPS objects, one for each date
+        """
+        # Login before using any method of provider
+        self.provider.login()
+
+        # Download csv data associated with this performance id
+        params_historydata = {'ClientId': self.provider.config['clientid'],
+                                'DataType': 'rips',
+                                'StartDate': start_date,
+                                'EndDate': end_date,
+                                'PriceType': str(return_type.value),
+                                'PerformanceId': performance_id}
+        return self.provider.history_data(params=params_historydata)
+
+
+
+    def get_historical_rips_by_fundshareclassid(self,
+                                                fundshareclass_id: str,
+                                                return_type: OnDemandReturnType,
+                                                start_date: str = '',
+                                                end_date: str = '') -> [RIPS]:
+        """Fetches historical RIPS for the fundshare with the given fundshareclass_id using 
+            the performance id associated with its base currency
+
+            Note: 
+                If no or more than 1 performance id in base currency is found, a ValueError is raised. 
+
+            Args:
+                fundshareclass_id (str): e.g. "F00000IRY4"
+                return_type (OnDemandReturnType): e.g. TotalReturn
+                start_date (str): "%Y-%m-%d"
+                end_date (str): "%Y-%m-%d"
+
+            Returns:
+                List of RIPS objects, one for each date
+        """
+        # Login before using any method of provider
+        self.provider.login()
+        
+        # Use the fundshareclass_id to retrieve the share's xml
+        params_sharexml = {'Package': 'EDW', 'IDType': 'FundShareClassId',
+                           'ClientId': self.provider.config['clientid'],
+                           'Id': fundshareclass_id}
+
+        root_n_share = self.provider.data_output(params=params_sharexml)
+
+        # Read out basecurrency's performance id
+        share_performanceid_basecurrency = root_n_share.xpath(
+            self.xpath_share_performanceid_basecurrency)
+        if len(share_performanceid_basecurrency) == 0:
+            raise ValueError("No performance id in basecurrency could be found")
+        if len(share_performanceid_basecurrency) > 1:
+            raise ValueError("More than 1 performance id in basecurrency was found: "+str(share_performanceid_basecurrency))
+        share_performanceid_basecurrency = str(
+            share_performanceid_basecurrency[0])
+
+        # Retrieve RIPS using performance id
+        return self.get_historical_rips_by_performanceid(performance_id=share_performanceid_basecurrency, 
+                                                        return_type=return_type, 
+                                                        start_date=start_date, 
+                                                        end_date=end_date)
+
+
+
+    def get_historical_rips_by_isin(self,
+                                    isin: str,
+                                    return_type: OnDemandReturnType,
+                                    start_date: str = '',
+                                    end_date: str = '',
+                                    universe: str = '') -> [RIPS]:
+        """Fetches historical RIPS for the fundshare with the given ISIN using the performance id in basecurrency
 
             Note:
-                The ISIN is searched in the specified universe to obtain the morningstar id its associated performance id.
+                The ISIN is searched in the specified universe to obtain the morningstar id. From the morningstar id,
+                the performance id associated with the base currency is used to retrieve the RIPS.
                 If the share is obsolete for too long (45d), or not found in the given universe, or if no
                 performance id in base currency can be found, a ValueError is raised. 
 
             Args:
-                isin (str): e.g. "IE00BYML7P29"
+                isin (str): e.g. "IE00B5BMR087"
                 return_type (OnDemandReturnType): e.g. TotalReturn
                 start_date (str): "%Y-%m-%d"
                 end_date (str): "%Y-%m-%d"
                 universe (str): e.g. "CHE"
 
             Returns:
-                List of RIPS objects with one for each date
+                List of RIPS objects, one for each date
             """
 
-        # Login before using any other method of provider
+        # Login before using any method of provider
         self.provider.login()
 
         # Get universe to find Morningstar Id corresponding to isin
-        #   no start and end date for search of isin in universe.
-        #   Should be everything possible
+        #   no start and end date for search of isin in universe, max length
         data_get_fundshare_universe = {'ClientId': self.provider.config['clientid'],
                                        'ActiveStatus':  '',     # obsolete and active, max coverage (last 45d)
                                        'InvestorType': '',      # both, dont care as only to get id
@@ -64,39 +143,18 @@ class OnDemandClient():
         #   It is unfortunately possible that a search by ISIN results in the correct fundshare which has
         #   a different ISIN than the one used for searching. In the resulting universe xml, it is also only
         #   listed with this other ISIN and hence cannot be found by subsetting in the xpath with the searched ISIN.
-        #   (ie by using [./ISIN = '"+isin+"'] in xpath). Therefore, because only maximum a single share 
-        #   should be found, read out directly withouth searching by ISIN in the xml
+        #   (ie by using [./ISIN = '"+isin+"'] in xpath). Therefore, because only a single share 
+        #   should be found, read out directly without searching by ISIN in the xml
         ms_id = root_n_universe.xpath(self.xpath_universe_morningstarid)
         if len(ms_id) == 0:
-            raise ValueError(
-                "No Morningstar Id could be found for the given ISIN. Maybe the share is dead for too long or in a different universe?")
+            raise ValueError("No Morningstar Id could be found for the given ISIN. Maybe the share is dead for too long or in a different universe?")
         if len(ms_id) > 1:
-            raise ValueError(
-                "More than one Morningstar Id found for this ISIN.")
+            raise ValueError("More than one Morningstar Id found for this ISIN.")
         ms_id = str(ms_id[0])
 
-        # With this morningstar id, get the respective share's xml and its performance id for basecurrency
-        params_sharexml = {'Package': 'EDW', 'IDType': 'FundShareClassId',
-                           'ClientId': self.provider.config['clientid'],
-                           'Id': ms_id}
-        root_n_share = self.provider.data_output(params=params_sharexml)
-
-        share_performanceid_basecurrency = root_n_share.xpath(
-            self.xpath_share_performanceid_basecurrency)
-        if len(share_performanceid_basecurrency) == 0:
-            raise ValueError(
-                "No performance id in basecurrency could be found")
-        if len(share_performanceid_basecurrency) > 1:
-            raise ValueError(
-                "More than 1 performance id in basecurrency was found: "+str(share_performanceid_basecurrency))
-        share_performanceid_basecurrency = str(
-            share_performanceid_basecurrency[0])
-
-        # Download csv data from this performance id
-        params_historydata = {'ClientId': self.provider.config['clientid'],
-                              'DataType': 'rips',
-                              'StartDate': start_date,
-                              'EndDate': end_date,
-                              'PriceType': str(return_type.value),
-                              'PerformanceId': share_performanceid_basecurrency}
-        return self.provider.history_data(params=params_historydata)
+        # Use the Morningstar Id to retrieve the RIPS of the basecurrency
+        return self.get_historical_rips_by_fundshareclassid(fundshareclass_id = ms_id, 
+                                                            return_type=return_type, 
+                                                            start_date=start_date, 
+                                                            end_date=end_date)
+    

--- a/morningstar/on_demand_client.py
+++ b/morningstar/on_demand_client.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 
 class OnDemandClient():
-
     xpath_share_performanceid_basecurrency = "/FundShareClass/PerformanceId/Result[./IsBaseCurrency = 'true']/PerformanceId/text()"
     xpath_universe_morningstarid = "/FundShareClassList/ShareClass/Id/text()"
 
@@ -22,14 +21,16 @@ class OnDemandClient():
         self.provider = provider
 
     def login(self):
-        # Login before using any method of provider
+        """
+        Establish a session before using any method of provider
+        """
         self.provider.login()
 
     def get_historical_rips_by_performanceid(self,
-                                            performance_id: str,
-                                            return_type: OnDemandReturnType,
-                                            start_date: str = '',
-                                            end_date: str = '') -> [RIPS]:
+                                             performance_id: str,
+                                             return_type: OnDemandReturnType,
+                                             start_date: str = '',
+                                             end_date: str = '') -> [RIPS]:
         """Fetches historical RIPS for the given performance id
 
             Args:
@@ -44,14 +45,12 @@ class OnDemandClient():
 
         # Download csv data associated with this performance id
         params_historydata = {'ClientId': self.provider.config['clientid'],
-                                'DataType': 'rips',
-                                'StartDate': start_date,
-                                'EndDate': end_date,
-                                'PriceType': str(return_type.value),
-                                'PerformanceId': performance_id}
+                              'DataType': 'rips',
+                              'StartDate': start_date,
+                              'EndDate': end_date,
+                              'PriceType': str(return_type.value),
+                              'PerformanceId': performance_id}
         return self.provider.history_data(params=params_historydata)
-
-
 
     def get_historical_rips_by_fundshareclassid(self,
                                                 fundshareclass_id: str,
@@ -87,17 +86,16 @@ class OnDemandClient():
         if len(share_performanceid_basecurrency) == 0:
             raise ValueError("No performance id in basecurrency could be found")
         if len(share_performanceid_basecurrency) > 1:
-            raise ValueError("More than 1 performance id in basecurrency was found: "+str(share_performanceid_basecurrency))
+            raise ValueError(
+                "More than 1 performance id in basecurrency was found: " + str(share_performanceid_basecurrency))
         share_performanceid_basecurrency = str(
             share_performanceid_basecurrency[0])
 
         # Retrieve RIPS using performance id
-        return self.get_historical_rips_by_performanceid(performance_id=share_performanceid_basecurrency, 
-                                                        return_type=return_type, 
-                                                        start_date=start_date, 
-                                                        end_date=end_date)
-
-
+        return self.get_historical_rips_by_performanceid(performance_id=share_performanceid_basecurrency,
+                                                         return_type=return_type,
+                                                         start_date=start_date,
+                                                         end_date=end_date)
 
     def get_historical_rips_by_isin(self,
                                     isin: str,
@@ -127,8 +125,8 @@ class OnDemandClient():
         # Get universe to find Morningstar Id corresponding to isin
         #   no start and end date for search of isin in universe, max length
         data_get_fundshare_universe = {'ClientId': self.provider.config['clientid'],
-                                       'ActiveStatus':  '',     # obsolete and active, max coverage (last 45d)
-                                       'InvestorType': '',      # both, dont care as only to get id
+                                       'ActiveStatus': '',  # obsolete and active, max coverage (last 45d)
+                                       'InvestorType': '',  # both, dont care as only to get id
                                        'LegalStructureId': '',  # all types of funds
                                        'ISIN': isin,
                                        'CountryId': universe}
@@ -142,14 +140,15 @@ class OnDemandClient():
         #   should be found, read out directly without searching by ISIN in the xml
         ms_id = root_n_universe.xpath(self.xpath_universe_morningstarid)
         if len(ms_id) == 0:
-            raise ValueError('No Morningstar Id could be found for ISIN {}. Maybe the share is dead for too long or in a different universe?'.format(isin))
+            raise ValueError(
+                'No Morningstar Id could be found for ISIN {}. Maybe the share is dead for too long or in a different universe?'.format(
+                    isin))
         if len(ms_id) > 1:
             raise ValueError('More than one Morningstar Id found for ISIN {}.'.format(isin))
         ms_id = str(ms_id[0])
 
         # Use the Morningstar Id to retrieve the RIPS of the basecurrency
-        return self.get_historical_rips_by_fundshareclassid(fundshareclass_id = ms_id, 
-                                                            return_type=return_type, 
-                                                            start_date=start_date, 
+        return self.get_historical_rips_by_fundshareclassid(fundshareclass_id=ms_id,
+                                                            return_type=return_type,
+                                                            start_date=start_date,
                                                             end_date=end_date)
-    

--- a/morningstar/on_demand_client.py
+++ b/morningstar/on_demand_client.py
@@ -142,9 +142,9 @@ class OnDemandClient():
         #   should be found, read out directly without searching by ISIN in the xml
         ms_id = root_n_universe.xpath(self.xpath_universe_morningstarid)
         if len(ms_id) == 0:
-            raise ValueError("No Morningstar Id could be found for the given ISIN. Maybe the share is dead for too long or in a different universe?")
+            raise ValueError('No Morningstar Id could be found for ISIN {}. Maybe the share is dead for too long or in a different universe?'.format(isin))
         if len(ms_id) > 1:
-            raise ValueError("More than one Morningstar Id found for this ISIN.")
+            raise ValueError('More than one Morningstar Id found for ISIN {}.'.format(isin))
         ms_id = str(ms_id[0])
 
         # Use the Morningstar Id to retrieve the RIPS of the basecurrency

--- a/morningstar/on_demand_client.py
+++ b/morningstar/on_demand_client.py
@@ -21,7 +21,9 @@ class OnDemandClient():
             provider = OnDemand(config=config.get('provider')['ondemand'])
         self.provider = provider
 
-
+    def login(self):
+        # Login before using any method of provider
+        self.provider.login()
 
     def get_historical_rips_by_performanceid(self,
                                             performance_id: str,
@@ -39,8 +41,6 @@ class OnDemandClient():
             Returns:
                 List of RIPS objects, one for each date
         """
-        # Login before using any method of provider
-        self.provider.login()
 
         # Download csv data associated with this performance id
         params_historydata = {'ClientId': self.provider.config['clientid'],
@@ -73,9 +73,7 @@ class OnDemandClient():
             Returns:
                 List of RIPS objects, one for each date
         """
-        # Login before using any method of provider
-        self.provider.login()
-        
+
         # Use the fundshareclass_id to retrieve the share's xml
         params_sharexml = {'Package': 'EDW', 'IDType': 'FundShareClassId',
                            'ClientId': self.provider.config['clientid'],
@@ -125,9 +123,6 @@ class OnDemandClient():
             Returns:
                 List of RIPS objects, one for each date
             """
-
-        # Login before using any method of provider
-        self.provider.login()
 
         # Get universe to find Morningstar Id corresponding to isin
         #   no start and end date for search of isin in universe, max length

--- a/morningstar/provider/morningstar.py
+++ b/morningstar/provider/morningstar.py
@@ -1,5 +1,6 @@
-import requests
 import logging
+
+import requests
 
 from morningstar.models.ms_response import MSResponse
 from morningstar.models.ts_response import TSResponse
@@ -46,14 +47,37 @@ class Morningstar(Provider):
         return self._request(base=base, params=params)
 
     def search(self, params):
+        """Search endpoint
+
+        Args:
+            params (dict): e.g. {"isin": "US46625H1005"}
+
+        Returns:
+
+        """
         response = self._tenfore('search', params)
         return MSResponse.from_dict(response)
 
     def index(self, params):
+        """Index endpoint
+
+        Args:
+            params (dict): e.g. {"isin": "US46625H1005"}
+
+        Returns:
+
+        """
         response = self._tenfore('index.php', params)
         return MSResponse.from_dict(response)
 
     def index_ts(self, params):
+        """IndexTS endpoint
+
+        Args:
+            params (dict): e.g. {"isin": "US46625H1005"}
+
+        Returns:
+
+        """
         response = self._morningstar('IndexTS', params)
         return TSResponse.from_dict(response)
-

--- a/morningstar/provider/on_demand.py
+++ b/morningstar/provider/on_demand.py
@@ -1,0 +1,61 @@
+import requests
+import logging
+import csv
+from morningstar.models.rips import RIPS
+import codecs
+from lxml import etree
+
+
+class OnDemand():
+    """OnDemand API
+
+    Note:
+        This class combines multiple endpoints:
+            - https://edw.morningstar.com/login.aspx
+            - https://edw.morningstar.com/Logout.aspx
+            - https://edw.morningstar.com/GetUniverseXML.aspx
+            - https://edw.morningstar.com/DataOutput.aspx
+            - https://edw.morningstar.com/HistoryData/HistoryData.aspx
+
+        Login needs to be called before using any of the other functions
+        If logout is called, all clients currently accessing the API are logged out
+
+    Attributes:
+        credentials (dict): Provider specific configuration including "username" and "password"
+    """
+
+    url_login = "https://edw.morningstar.com/login.aspx"
+    url_logout = "https://edw.morningstar.com/Logout.aspx"
+    url_getuniverse = "https://edw.morningstar.com/GetUniverseXML.aspx"
+    url_dataoutput = "https://edw.morningstar.com/DataOutput.aspx"
+    url_historydata = "https://edw.morningstar.com/HistoryData/HistoryData.aspx"
+
+    def __init__(self, config):
+        self.config = config
+
+    def login(self):
+        self.sess = requests.Session()
+        ms_data_login = {
+            'email': self.config['username'], 'password': self.config['password']}
+        self.sess.post(self.url_login, data=ms_data_login)
+
+    def logout(self):
+        ms_data_logout = {'clientid': self.config['clientid']}
+        self.sess.post(url=self.url_logout, data=ms_data_logout)
+
+    def _xml_from_url(self, url: str, params: dict):
+        r_url = self.sess.get(url, params=params)
+        return etree.fromstring(r_url.content)
+
+    def get_universe(self, params: dict) -> [etree]:
+        return self._xml_from_url(url=self.url_getuniverse, params=params)
+
+    def data_output(self, params: dict) -> [etree]:
+        return self._xml_from_url(url=self.url_dataoutput, params=params)
+
+    def history_data(self, params: dict) -> [RIPS]:
+        with self.sess.get(self.url_historydata, params=params) as r_download_csv:
+            # read rows as dict to convert to rips class
+            cr = csv.DictReader(codecs.iterdecode(
+                r_download_csv.iter_lines(), 'utf-8'), delimiter=';')
+            return [RIPS.from_dict(row_dict) for row_dict in cr]

--- a/morningstar/provider/provider.py
+++ b/morningstar/provider/provider.py
@@ -10,39 +10,3 @@ class Provider(ABC):
             config (dict): dictionary containing configuration parameters
         """
         self.config = config
-
-    @abstractmethod
-    def search(self, params: dict):
-        """Search endpoint
-
-        Args:
-            params (dict): e.g. {"isin": "US46625H1005"}
-
-        Returns:
-
-        """
-        pass
-
-    @abstractmethod
-    def index(self, params: dict):
-        """Index endpoint
-
-        Args:
-            params (dict): e.g. {"isin": "US46625H1005"}
-
-        Returns:
-
-        """
-        pass
-
-    @abstractmethod
-    def index_ts(self, params: dict):
-        """IndexTS endpoint
-
-        Args:
-            params (dict): e.g. {"isin": "US46625H1005"}
-
-        Returns:
-
-        """
-        pass

--- a/morningstar/spec/on_demand_spec.py
+++ b/morningstar/spec/on_demand_spec.py
@@ -1,0 +1,42 @@
+from enum import Enum
+
+
+class OnDemandReturnType(Enum):
+    """ Morningstar Return Types in OnDemand
+
+    Morningstar On Demand Webportal Dictionary - Return Types
+    """
+    TotalReturn = "1"
+    LoadAdjustedReturn = "2"
+    SECPreLiquidationReturn = "3"
+    SECPostLiquidationReturn = "4"
+    TaxCostRatioReturn_PreLiquidation = "5"
+    MarketReturn = "6"
+    IncomeReturn_PreTax = "7"
+    CapitalGainReturn = "8"
+    PremiumDiscountReturn = "9"
+    IndexReturn = "10"
+    TaxableEquivalentReturn = "11"
+    NonStandardized_LoadAdjustedReturn = "12"
+    GrossManagementFeeReturn = "13"
+    SECPreLiquidationReturn_MarketPrice = "14"
+    SECPostLiquidationReturn_MarketPrice = "15"
+    TaxCostRatioReturn_PreLiquidation_MarketPrice = "16"
+    PriceReturn = "17"
+    TaxAdjustedReturn = "18"
+    ExchangeRateReturn = "19"
+    InvestorReturn = "20"
+    NonAuditedReturn = "21"
+    PreliminaryReturn = "31"
+    EPRTotalReturn = "101"
+    EPRLoadAdjustedReturn = "102"
+    EPRNonStandardizedLoadAdjustedReturn = "112"
+    PreInceptionTotalReturn = "201"
+    PreInceptionLoadAdjustedReturn = "202"
+    PreInceptionNASDNonStandardizedReturn = "212"
+    SurvivorshipBiasFreeReturn = "301"
+    TaxCostRatioReturn_PostLiquidation = "25"
+    SECStandardizedReturn = "22"
+    TaxAndLoadAdjustedReturn = "23"
+    TaxAdjustedIncomeReturn = "27"
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml
 pytest
 requests
+lxml

--- a/tests/morningstar_test.py
+++ b/tests/morningstar_test.py
@@ -88,5 +88,5 @@ class MorningstarTest(unittest.TestCase):
     def test_indexts_no_data(self):
         r = self.provider_live.index_ts(
             {'instrument': '0.0.NONEXISTENT', 'sdate': '01-01-2019', 'edate': '01-01-2019', 'type': 'dailybar'})
-        self.assertEqual(['Invalid Instrument=0.0.NONEXISTENT', 'Invalid request'], r.errors)
+        self.assertEqual(['Invalid Instrument=0.0.NONEXISTENT'], r.errors)
         self.assertEqual([], r.results)


### PR DESCRIPTION
Add functionality to retrieve data from morningstar's On Demand interface. This currently only includes historical RIPS, fetched by ISIN, fundshareclass id, and performance id. 