### PR TITLE
Bugfix: PriceType is not forwarded to historical data link

### DIFF
--- a/morningstar/on_demand_client.py
+++ b/morningstar/on_demand_client.py
@@ -48,7 +48,7 @@ class OnDemandClient():
                               'DataType': 'rips',
                               'StartDate': start_date,
                               'EndDate': end_date,
-                              'PriceType': str(return_type.value),
+                              'PriceTypeId': str(return_type.value),
                               'PerformanceId': performance_id}
         return self.provider.history_data(params=params_historydata)
 


### PR DESCRIPTION
Build dict for parameters correctly
Key `PriceType` should have been `PriceTypeId`